### PR TITLE
feat: expose dialog instance context and control functions in request…

### DIFF
--- a/.changeset/add-dialog-context.md
+++ b/.changeset/add-dialog-context.md
@@ -1,0 +1,9 @@
+---
+"@rokku-x/react-hook-dialog": minor
+---
+
+Expose dialog instance context and control functions on the value returned by `requestDialog(...)`.
+
+The Promise returned from `requestDialog` is now an augmented `RequestDialogReturnType<T>` (`Promise<T> & { id: string; context: DialogInstanceContext }`) which allows programmatic control while the dialog is open (for example `p.context.forceCancel()`, `p.context.forceAction(...)`, or `p.context.forceDefault()`).
+
+Optimized imports and usage of `ModalWindow` component and `useBaseModal` hook to ensure proper dialog rendering and management.

--- a/src/hooks/useHookDialog.ts
+++ b/src/hooks/useHookDialog.ts
@@ -1,8 +1,6 @@
-import React, { useCallback } from "react";
 import { useBaseModal } from '@rokku-x/react-hook-modal';
-import ModalWindow from "@/components/ModalWindow";
 import { useDialogStore } from "@/store/dialogStore";
-import type { FormDataObject, ConfirmConfig, ConfirmInstance, UseHookDialogConfig, ValidValue, ModalAction } from '@/types'
+import type { FormDataObject, ConfirmConfig, ConfirmInstance, UseHookDialogConfig, ValidValue, ModalAction, RequestDialogReturnType, UseHookDialogReturnType } from '@/types'
 
 /**
  * Hook for displaying confirmation dialogs and alerts.
@@ -40,58 +38,45 @@ import type { FormDataObject, ConfirmConfig, ConfirmInstance, UseHookDialogConfi
  * ```
  */
 export default function useHookDialog<T = ValidValue>(defaultConfig?: UseHookDialogConfig) {
-    const { instances, addInstance, removeInstance, getInstance } = useDialogStore();
+    const { addInstance, handleAction, handleClose, getContext } = useDialogStore();
     const baseModalInstance = useBaseModal();
-
-    const handleClose = useCallback((id: string) => {
-        const modal = getInstance(id);
-        if (!modal) return;
-        baseModalInstance.popModal(id);
-
-        if (modal.config.rejectOnCancel !== false) modal.reject(modal.config.defaultCancelValue);
-        else modal.resolve(modal.config.defaultCancelValue);
-        removeInstance(id);
-    }, [getInstance, removeInstance, baseModalInstance]);
-
-    const handleAction = useCallback((id: string, action: ModalAction) => {
-        const modal = getInstance(id);
-        if (!modal) return;
-        baseModalInstance.popModal(id);
-
-        if (action.isCancel) {
-            if (modal.config.rejectOnCancel !== false) modal.reject(action.value);
-            else modal.resolve(action.value);
-        } else {
-            modal.resolve(action.value);
-        }
-
-        removeInstance(id);
-    }, [getInstance, removeInstance, baseModalInstance]);
 
     // Overloads allow consumers to narrow the Promise result type:
     // - When `isReturnSubmit: true` is provided in the config, the default result is a `FormDataObject` (but can be overridden via generic)
     // - Otherwise the default is `T` (the hook's generic)
     function requestDialog<U = FormDataObject>(config: ConfirmConfig & { isReturnSubmit: true }): Promise<U>
-    function requestDialog<U = T>(config: ConfirmConfig): Promise<U>
-    function requestDialog<U = any>(config: ConfirmConfig): Promise<U> {
-        return new Promise<U>((resolve, reject) => {
-            const id = Math.random().toString(36).substring(2, 6);
-            const mergedConfig: ConfirmConfig = {
-                ...defaultConfig,
-                ...config,
-                classNames: {
-                    ...defaultConfig?.classNames,
-                    ...config.classNames,
-                },
-                styles: {
-                    ...defaultConfig?.styles,
-                    ...config.styles,
-                },
-                variantStyles: {
-                    ...defaultConfig?.variantStyles,
-                    ...config.variantStyles,
-                },
-            };
+    function requestDialog<U = T>(config: ConfirmConfig): Promise<U> {
+        const id = Math.random().toString(36).substring(2, 6);
+
+        //check actions if there are multiple focused actions
+        const focusedActions = config.actions?.flat().filter(action => action.isFocused) || [];
+        if (focusedActions.length > 1) console.warn(`useHookDialog: Multiple actions are marked as isFocused in dialog "${id}". Only one action should be focused.`);
+
+        //check actions if there is at least one action marked as cancel
+        const hasCancelAction = config.actions?.some(row => row.some(action => action.isCancel));
+
+        // If no cancel action is defined, and backdropCancel config is undefined, we treat backdrop clicks as cancel
+        const backdropCancel = config.backdropCancel ?? defaultConfig?.backdropCancel ?? !hasCancelAction;
+
+        const mergedConfig: ConfirmConfig = {
+            ...defaultConfig,
+            ...config,
+            classNames: {
+                ...defaultConfig?.classNames,
+                ...config.classNames,
+            },
+            styles: {
+                ...defaultConfig?.styles,
+                ...config.styles,
+            },
+            variantStyles: {
+                ...defaultConfig?.variantStyles,
+                ...config.variantStyles,
+            },
+            backdropCancel,
+        };
+
+        const promise = new Promise<U>((resolve, reject) => {
             const newInstance: ConfirmInstance<U> = {
                 id,
                 config: mergedConfig,
@@ -99,10 +84,16 @@ export default function useHookDialog<T = ValidValue>(defaultConfig?: UseHookDia
                 reject,
             };
             addInstance(newInstance);
-
-            newInstance.id = baseModalInstance.pushModal(id, React.createElement(ModalWindow, { config: mergedConfig, modalWindowId: id, handleClose, handleAction }));
         });
+
+        Object.defineProperties(promise, {
+            'context': { get() { return getContext(id); }, enumerable: true, configurable: false },
+            'id': { get() { return id }, enumerable: true, configurable: false }
+        })
+
+        return promise as RequestDialogReturnType<U>;
     };
 
-    return [requestDialog];
+    return [requestDialog, getContext] as UseHookDialogReturnType<T>;
 }
+

--- a/src/store/dialogStore.ts
+++ b/src/store/dialogStore.ts
@@ -1,4 +1,7 @@
-import type { ConfirmInstance, ValidValue } from '@/types';
+import ModalWindow from '@/components/ModalWindow';
+import type { ConfirmInstance, ModalAction, ValidValue } from '@/types';
+import { useBaseModal } from '@rokku-x/react-hook-modal';
+import React from 'react';
 import { create } from 'zustand';
 
 /**
@@ -16,9 +19,21 @@ interface DialogStore<T = ValidValue> {
     /** Remove a dialog instance from the store by ID */
     removeInstance: (id: string) => void;
 
+    /** Handle closing a dialog instance */
+    handleClose: (id: string, isForceCancel?: boolean) => void;
+
+    /** Handle an action taken on a dialog instance */
+    handleAction: (id: string, action: ModalAction) => void;
+
     /** Get a dialog instance by ID */
     getInstance: (id: string) => ConfirmInstance<T> | undefined;
+
+    /** Get the context of a dialog instance by ID */
+    getContext: (id: string) => { id: string; config: any; forceCancel: () => void } | undefined;
 }
+
+// Get base modal instance for managing modal stack
+const baseModalInstance = useBaseModal();
 
 /**
  * Zustand store for managing dialog instances.
@@ -32,13 +47,54 @@ interface DialogStore<T = ValidValue> {
  */
 export const useDialogStore = create<DialogStore<any>>((set, get) => ({
     instances: [],
-    addInstance: (instance: ConfirmInstance) =>
+    addInstance: (instance: ConfirmInstance) => {
         set((state) => ({
             instances: [...state.instances, instance],
-        })),
+        }));
+        instance.id = baseModalInstance.pushModal(instance.id, React.createElement(ModalWindow, { config: instance.config, modalWindowId: instance.id, handleClose: get().handleClose, handleAction: get().handleAction }));
+    },
     removeInstance: (id: string) =>
         set((state) => ({
             instances: state.instances.filter((m) => m.id !== id),
         })),
+    handleClose: (id: string, isForceCancel: boolean = false) => {
+        const modal = get().getInstance(id);
+        if (!modal) return;
+        baseModalInstance.popModal(id);
+
+        if (modal.config.rejectOnCancel !== false || isForceCancel) modal.reject(modal.config.defaultCancelValue);
+        else modal.resolve(modal.config.defaultCancelValue);
+
+        get().removeInstance(id);
+    },
+    handleAction: (id: string, action: ModalAction) => {
+        const modal = get().getInstance(id);
+        if (!modal) return;
+        baseModalInstance.popModal(id);
+
+        if (action.isCancel) {
+            if (modal.config.rejectOnCancel !== false) modal.reject(action.value);
+            else modal.resolve(action.value);
+        } else {
+            modal.resolve(action.value);
+        }
+
+        get().removeInstance(id);
+    },
+    getContext: (id: string) => {
+        const modal = get().getInstance(id);
+        if (!modal) throw new Error(`Dialog instance with id "${id}" not found.`);
+        return {
+            id: modal.id,
+            config: modal.config,
+            forceCancel: (forceReject: boolean = true) => get().handleClose(id, forceReject),
+            forceAction: (action: ModalAction) => { get().handleAction(id, action); },
+            forceDefault: () => {
+                const firstDefaultAction = modal.config.actions?.flat().find((action) => action.isFocused);
+                if (!firstDefaultAction) throw new Error(`No default action (isFocused) defined for dialog instance with id "${id}".`);
+                get().handleAction(id, firstDefaultAction);
+            }
+        };
+    },
     getInstance: (id: string) => get().instances.find((m) => m.id === id) as ConfirmInstance | undefined,
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -293,3 +293,24 @@ interface HandleActionCallback {
  * Friendly Form Data object type
  */
 export type FormDataObject = Record<string, FormDataEntryValue | FormDataEntryValue[]>;
+
+/** Function type for requesting a dialog*/
+export interface RequestDialog<U> {
+    <U = FormDataObject>(config: ConfirmConfig & { isReturnSubmit: true }): RequestDialogReturnType<U>;
+    <U = ValidValue>(config: ConfirmConfig): RequestDialogReturnType<U>;
+}
+
+/** Context information for a dialog instance */
+export type DialogInstanceContext = {
+    id: string;
+    config: any;
+    forceCancel: (forceReject?: boolean) => void,
+    forceAction: (action: ModalAction) => void,
+    forceDefault: () => void
+};
+
+/** Return type of the requestDialog function with added context property */
+export type RequestDialogReturnType<T> = Promise<T> & { id: string, context: DialogInstanceContext };
+
+/** Return type of the useHookDialog hook */
+export type UseHookDialogReturnType<T> = [requestDialog: RequestDialog<T>, getContext: (id: string) => DialogInstanceContext]; 


### PR DESCRIPTION

This pull request introduces a new dialog context API for the `@rokku-x/react-hook-dialog` library, allowing for enhanced programmatic control over dialog instances. The main improvement is that the Promise returned by `requestDialog(...)` now exposes both a unique dialog ID and a context object with methods to control the dialog (e.g., force cancel, force specific actions, or trigger the default action). The documentation and type definitions have been updated accordingly, and dialog instance management has been refactored to support these features.

**Dialog Context API and Programmatic Control**
* The Promise returned by `requestDialog` is now an augmented type (`RequestDialogReturnType<T>`) that includes both an `id` and a `context` object. This context provides methods such as `forceCancel()`, `forceAction(...)`, and `forceDefault()` for programmatic control of the dialog. [[1]](diffhunk://#diff-b1ae8669fea16c5c164b22bb90d23e50e89d2adb010c11eaa4d89dde0fb37799R1-R9) [[2]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R296-R316)
* The `useHookDialog` hook now returns a tuple: `[requestDialog, getContext]`, allowing consumers to access dialog context either directly from the returned promise or via the `getContext(id)` helper. [[1]](diffhunk://#diff-52acc8aaba31bc11ebe58c9dfa280b090b72d80e852df66015c14e213a4296fcR76-R99) [[2]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R296-R316)

**Dialog Instance Management Refactor**
* Dialog instance handling in `useDialogStore` has been refactored to support the new context API, including new methods for handling dialog actions and closures, and for retrieving dialog context by ID. [[1]](diffhunk://#diff-064e9d6bdaafe6d27062ee5fc6063f21f45b9576a8a4847d12fcc22f2c64bbb3R22-R37) [[2]](diffhunk://#diff-064e9d6bdaafe6d27062ee5fc6063f21f45b9576a8a4847d12fcc22f2c64bbb3L35-R98)
* Dialog instances are now rendered and managed using the `ModalWindow` component and the `useBaseModal` hook, ensuring correct dialog rendering and lifecycle management. [[1]](diffhunk://#diff-064e9d6bdaafe6d27062ee5fc6063f21f45b9576a8a4847d12fcc22f2c64bbb3L1-R4) [[2]](diffhunk://#diff-064e9d6bdaafe6d27062ee5fc6063f21f45b9576a8a4847d12fcc22f2c64bbb3L35-R98) [[3]](diffhunk://#diff-52acc8aaba31bc11ebe58c9dfa280b090b72d80e852df66015c14e213a4296fcL1-R3)

**Documentation and Type Updates**
* The README has been updated to document the new context API, including usage examples and details about the new force methods.
* New TypeScript types have been introduced to support the new API, including `RequestDialogReturnType`, `DialogInstanceContext`, and an updated signature for `requestDialog`.

**Dialog Behavior Improvements**
* Additional logic ensures proper handling of dialog actions, such as warning if multiple actions are marked as focused and improved default cancel behavior if no cancel action is defined.

These changes collectively provide a more powerful and flexible dialog API for consumers, enabling advanced dialog workflows and better integration with application logic.